### PR TITLE
Hotfix / Improve scores feed performance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-22
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.includes(:user).order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION
Fixes: [#1 ](https://github.com/AACraiu/golfr_backend/issues/1)

**Changes**

When calling api/feed, every individual score queried for their respective user.
By changing:
`scores = Score.all.order(played_at: :desc, id: :desc)`
To:
`scores = Score.all.includes(:user).order(played_at: :desc, id: :desc)`
We load all the scores with their associated user at once, reducing the total number of queries.

**Before**

<img width="832" alt="Screenshot 2023-08-02 at 4 24 12 PM" src="https://github.com/AACraiu/golfr_backend/assets/92330663/3984e269-cf16-407a-a7c4-a29a0c8354e3">


**After**

<img width="855" alt="Screenshot 2023-08-02 at 4 24 30 PM" src="https://github.com/AACraiu/golfr_backend/assets/92330663/0503372f-cd51-4d0f-86de-255402604e24">
