### PR TITLE
Feature / Limit the number of scores in the feed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-22
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.includes(:user).limit(25).order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,11 +29,11 @@ User.create!(
 rng = Random.new
 now = Time.zone.today
 User.all.each do |user|
-  5.times do |i|
+  35.times do |i|
     Score.create!(
       user: user,
       total_score: rng.rand(66..99),
-      played_at: now - 5.days + i.days
+      played_at: now - 50.days + i.days
     )
   end
 end

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -26,6 +26,20 @@ describe Api::ScoresController, type: :request do
       expect(scores[1]['total_score']).to eq 68
       expect(scores[2]['total_score']).to eq 79
     end
+
+    it 'should return 25 scores on feed' do
+      50.times do
+        create(:score, user: @user1, total_score: 65, played_at: '2022-05-20')
+      end
+
+      get api_feed_path
+
+      expect(response).to have_http_status(:ok)
+      response_hash = JSON.parse(response.body)
+      scores = response_hash['scores']
+
+      expect(scores.size).to eq 25
+    end
   end
 
   describe 'POST create' do


### PR DESCRIPTION
Fixes: [#21](https://github.com/AACraiu/golfr_backend/issues/21)

**Changes**

By adding, 
`scores = Score.all.includes(:user).limit(25).order(played_at: :desc, id: :desc)`
the user controller queries only for 25 rows in the database.
To ensure proper functionality a test was written which checks that the feed is no longer than 25 scores.

**Before**

<img width="1490" alt="Screenshot 2023-08-04 at 1 21 02 PM" src="https://github.com/egondohr22/golfr_backend/assets/92330663/c1a57cfd-8172-455c-bf10-e0accb1747ef">

**After**

<img width="1489" alt="Screenshot 2023-08-04 at 1 21 23 PM" src="https://github.com/egondohr22/golfr_backend/assets/92330663/198a9f0b-df79-45e7-9e0f-529578246227">

